### PR TITLE
feat: add extra disk to ec2 instance

### DIFF
--- a/gha-runner.pkr.hcl
+++ b/gha-runner.pkr.hcl
@@ -67,6 +67,13 @@ source "amazon-ebs" "ubuntu" {
   ssh_username         = var.ssh_username
   ssh_private_key_file = var.ssh_private_key_file_path
   ssh_keypair_name     = var.ssh_keypair_name
+
+  ami_block_device_mappings {
+    device_name = "/dev/sdb"
+    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 50
+  }
 }
 
 build {

--- a/lambda/template.yaml
+++ b/lambda/template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
   Lambda function for managing EC2 instances to be used as self hosted runners for Github
@@ -8,11 +8,11 @@ Globals:
     Timeout: 30
 Parameters:
   AmiId:
-    Default: ami-05b371382b07cb80a
+    Default: ami-0040e65f0c9cc3b36
     Description: The AMI for the EC2 instance to be launched
     Type: String
   Ec2InstanceType:
-    Default: t2.medium
+    Default: c5.9xlarge
     Description: The size of the EC2 instance to be launched
     Type: String
   Ec2KeyName:
@@ -45,9 +45,9 @@ Resources:
             Method: post
       Environment:
         Variables:
-          GITHUB_APP_ID: '{{resolve:secretsmanager:gha_runner_github_app_id}}'
-          GITHUB_APP_PRIVATE_KEY_BASE64: '{{resolve:secretsmanager:gha_runner_github_private_key_base64}}'
-          GITHUB_APP_SECRET: '{{resolve:secretsmanager:gha_runner_github_app_secret}}'
+          GITHUB_APP_ID: "{{resolve:secretsmanager:gha_runner_github_app_id}}"
+          GITHUB_APP_PRIVATE_KEY_BASE64: "{{resolve:secretsmanager:gha_runner_github_private_key_base64}}"
+          GITHUB_APP_SECRET: "{{resolve:secretsmanager:gha_runner_github_app_secret}}"
           AMI_ID: !Sub "${AmiId}"
           EC2_INSTANCE_TYPE: !Sub "${Ec2InstanceType}"
           EC2_KEY_NAME: !Sub "${Ec2KeyName}"

--- a/lambda/template.yaml
+++ b/lambda/template.yaml
@@ -8,8 +8,12 @@ Globals:
     Timeout: 30
 Parameters:
   AmiId:
-    Default: ami-0040e65f0c9cc3b36
+    Default: ami-05b4e01eee76b396b
     Description: The AMI for the EC2 instance to be launched
+    Type: String
+  Ec2IamInstanceProfile:
+    Default: arn:aws:iam::389640522532:instance-profile/upload_build_artifacts
+    Description: The ARN of the IAM instance profile for the EC2 instance to be launched
     Type: String
   Ec2InstanceType:
     Default: c5.9xlarge
@@ -49,6 +53,7 @@ Resources:
           GITHUB_APP_PRIVATE_KEY_BASE64: "{{resolve:secretsmanager:gha_runner_github_private_key_base64}}"
           GITHUB_APP_SECRET: "{{resolve:secretsmanager:gha_runner_github_app_secret}}"
           AMI_ID: !Sub "${AmiId}"
+          EC2_IAM_INSTANCE_PROFILE: !Sub "${Ec2IamInstanceProfile}"
           EC2_INSTANCE_TYPE: !Sub "${Ec2InstanceType}"
           EC2_KEY_NAME: !Sub "${Ec2KeyName}"
           EC2_SECURITY_GROUP_ID: !Sub "${Ec2SecurityGroupId}"

--- a/scripts/init-runner.sh
+++ b/scripts/init-runner.sh
@@ -38,3 +38,8 @@ chmod +x rustup-init
 # step in an actions workflow.
 sudo ln -s ~/.cargo/bin/* /usr/local/bin
 rustup target add x86_64-unknown-linux-musl
+
+cd /tmp
+curl -O "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+unzip awscli-exe-linux-x86_64.zip
+sudo ./aws/install

--- a/scripts/init-runner.sh
+++ b/scripts/init-runner.sh
@@ -5,7 +5,10 @@ retry_count=1
 packages_installed="false"
 while [[ $retry_count -le 20 ]]; do
   echo "Attempting to install packages..."
-  sudo DEBIAN_FRONTEND=noninteractive apt install docker.io git -y
+  # All these packages are necessary for a full build of all safe_network code,
+  # including test binaries.
+  sudo DEBIAN_FRONTEND=noninteractive apt install -y \
+    build-essential docker.io git libssl-dev musl-tools pkg-config ripgrep unzip
   exit_code=$?
   if [[ $exit_code -eq 0 ]]; then
       echo "packages installed successfully"
@@ -26,3 +29,12 @@ fi
 
 sudo systemctl enable docker
 sudo usermod --groups docker ubuntu
+
+curl -L -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
+chmod +x rustup-init
+./rustup-init --default-toolchain stable -y --no-modify-path
+# Make Cargo related binaries available in a system-wide location.
+# This prevents difficulties with having to source ~/.cargo/env in every shell
+# step in an actions workflow.
+sudo ln -s ~/.cargo/bin/* /usr/local/bin
+rustup target add x86_64-unknown-linux-musl


### PR DESCRIPTION
- d563ca0 **feat: add extra disk to ec2 instance**

  The main disk on the instance is nearly full, which prevents safe_network from being able to build
  completely. The dependency graph uses space and Cargo also makes use of temporary space during its
  build process.

  The Packer template is updated to instruct the AMI to attach an extra 50gb disk to the instance
  that gets launched, and the user data script gets extended to format and mount the disk. We create
  directories for tmp, `CARGO_HOME` and the Github runner, where the workspace and code will be
  checked out. There is a little loop in the script to wait for the additional disk to become
  available, since sometimes it's not attached by the time this script runs.

  In any actions job that uses the self-hosted runner we should set `TMPDIR` and `CARGO_HOME` to the
  locations provided here.

- 1697101 **feat: extend ami with cargo and musl**

  Several packages are provided that allow the machine to perform a complete build of the
  `safe_network` repository, including test code.

  The Cargo installation symlinks all the binaries to a system-wide location. This is because I ran
  into some problems with the runner process not having a full login shell environment and I had to
  end up having a `source ~/.cargo/env` command in every `shell` step that used Cargo. We can just
  symlink the binaries to `/usr/local/bin` to avoid this.

- 6830b57 **feat: launch ec2 instance with iam instance profile**

  The upload_build_artifacts IAM instance profile allows us to upload build artifacts to the
  `maidsafe-build-artifacts` S3 bucket. When the `aws` CLI is invoked on the instance it will assume
  this instance profile. This avoids creating another machine user and provisioning their security
  credentials on the instance.