### PR TITLE
Launch Testnets from EC2 Runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ deploy-create-instance-function:
 	)
 	docker push $$AWS_ACCOUNT_NUMBER.${REGISTRY_URI}/${REPO_NAME}:${TAG_NAME}
 	(
-		security_group_id=$$(terraform output -raw gha_runner_security_group_name | xargs)
+		security_group_id=$$(terraform output -raw gha_runner_image_security_group_name | xargs)
 		subnet_id=$$(terraform output subnet_name | xargs | awk '{ print $$2 }' | sed s/,//)
 		cd lambda
 		sam deploy \

--- a/lambda/template.yaml
+++ b/lambda/template.yaml
@@ -8,7 +8,7 @@ Globals:
     Timeout: 30
 Parameters:
   AmiId:
-    Default: ami-05b4e01eee76b396b
+    Default: ami-00632730219704074
     Description: The AMI for the EC2 instance to be launched
     Type: String
   Ec2IamInstanceProfile:

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,17 @@ resource "aws_security_group" "gha_runner" {
   vpc_id = module.vpc.vpc_id
 }
 
+# For using the GHA runner to launch a testnet, you need to have port 22 open, because Terraform
+# uses SSH to check if machines have become available.
+resource "aws_security_group_rule" "gha_runner_egress_ssh" {
+  type = "egress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.gha_runner.id
+}
+
 resource "aws_security_group_rule" "gha_runner_egress_https" {
   type = "egress"
   from_port = 443

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,10 @@ output "subnet_name" {
 }
 
 output "gha_runner_security_group_name" {
+  value = aws_security_group.gha_runner.id
+}
+
+output "gha_runner_image_builder_security_group_name" {
   value = aws_security_group.gha_runner_image_builder.id
 }
 

--- a/scripts/init-runner.sh
+++ b/scripts/init-runner.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+TERRAFORM_VERSION="1.3.5"
+TERRAFORM_ARCHIVE_NAME="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ARCHIVE_NAME}"
+
 sudo DEBIAN_FRONTEND=noninteractive apt update
 retry_count=1
 packages_installed="false"
@@ -8,7 +12,7 @@ while [[ $retry_count -le 20 ]]; do
   # All these packages are necessary for a full build of all safe_network code,
   # including test binaries.
   sudo DEBIAN_FRONTEND=noninteractive apt install -y \
-    build-essential docker.io git libssl-dev musl-tools pkg-config ripgrep unzip
+    build-essential docker.io git jq libssl-dev musl-tools pkg-config ripgrep unzip
   exit_code=$?
   if [[ $exit_code -eq 0 ]]; then
       echo "packages installed successfully"
@@ -43,3 +47,7 @@ cd /tmp
 curl -O "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
 unzip awscli-exe-linux-x86_64.zip
 sudo ./aws/install
+
+curl -O $TERRAFORM_URL
+unzip $TERRAFORM_ARCHIVE_NAME
+sudo mv terraform /usr/local/bin


### PR DESCRIPTION
- cbde68a **feat: outbound ssh access for gha runner**

  This enables the runner to be used to launch a testnet. See the comment on the diff.

- a89869d **feat: install terraform on the ami**

  Also rebuild the AMI and update the Lambda to use the new ID.