### PR TITLE
Resurrect Infra for Self-Hosted Build Agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ infrastructure:
 
 .ONESHELL:
 build-image:
-	security_group_id=$$(terraform output -raw gha_runner_security_group_name | xargs)
+	security_group_id=$$(terraform output -raw gha_runner_image_builder_security_group_name | xargs)
 	subnet_id=$$(terraform output subnet_name | xargs | awk '{ print $$2 }' | sed s/,//)
 	packer init .
 	packer build -var="security_group_id=$$security_group_id" \
@@ -25,7 +25,7 @@ deploy-create-instance-function:
 	)
 	docker push $$AWS_ACCOUNT_NUMBER.${REGISTRY_URI}/${REPO_NAME}:${TAG_NAME}
 	(
-		security_group_id=$$(terraform output -raw gha_runner_image_security_group_name | xargs)
+		security_group_id=$$(terraform output -raw gha_runner_security_group_name | xargs)
 		subnet_id=$$(terraform output subnet_name | xargs | awk '{ print $$2 }' | sed s/,//)
 		cd lambda
 		sam deploy \

--- a/README.md
+++ b/README.md
@@ -2,14 +2,64 @@
 
 Defines infrastructure for CI-related processes.
 
-We have a requirement for build agents with improved speed and memory capacity than those offered by
-the Github Actions infrastructure. This repository automates the creation of a VPC where EC2
-instances can be launched and used as a runner for a job in Github Actions. The image for the runner
-is also automated. Both configurations can be extended as need be, as and when new requirements
-arise.
+## Github Actions Self-hosted Build Agents
 
-There are instructions for building the infrastructure, but we may also automate these processes
-using Github Actions workflows.
+On Github Actions, you can supply your own self-hosted build agents. We provide a setup for running
+those agents on AWS EC2. The EC2 instance uses the Github runner service to register the build agent
+in any repositories that are configured with the Github App, and this then makes it available for
+use in any workflow jobs that are marked `runs-on: self-hosted`.
+
+There are a few different components involved in the setup, so at first, it can seem confusing.
+However, once explained, it's quite straight forward. Please read this section to understand the
+solution.
+
+### Github App
+
+We have defined our own Github App, [AWS Hosted GHA Runners (Linux)](https://github.com/apps/aws-hosted-gha-runners-linux).
+
+The app is installed on the `maidsafe` organisation and it's configured to be able to access a
+single repository, `safe_network`. For repositories for which it's configured, it gets access to
+their Github Actions Workflow runs. This allows it to subscribe to `Workflow job` events. Those
+events occur when a job in a workflow is queued, starts, completes, and so on. When the app receives
+one of those events, it posts a JSON document to a webhook. The webhook is configurable, and it can
+point to absolutely anything, but in our case, it is the endpoint for an AWS Lambda function. The
+Lambda will launch or stop an EC2 instance, based on the type of event. It will be described in more
+detail shortly.
+
+There are three secrets associated with the app. The first is the client secret, which is defined,
+but not used as part of our solution. The second is the webhook secret, or the app secret, which is
+used to validate requests sent to the webhook. The third is the private key, which is used to sign
+tokens used in requests to the Github API. The API is used to register the Github build agent
+service that runs on the EC2 instance.
+
+### AWS EC2
+
+Since we run the build agents on EC2 instances, we need a bit of infrastructure to support that:
+
+* A VPC configured with internet access for building the AMI and fetching crates
+* A security group that grants internet access
+* A security group that allows SSH access to the instance for building the AMI for the build agent
+
+### AWS Lambda
+
+A simple Lambda function is defined in Python. It gets pushed to a Docker registry in the AWS
+account and then runs in the AWS infrastructure.
+
+The function performs the following steps:
+
+* The workflow job event is received from a request posted to the webhook by the Github App
+* The request is checked for a signature in its header
+* The signature is validated using the app secret
+* If the action for the workflow job is `queued`:
+    - Sign a token for a Github API request using the Github App private key.
+    - Use the token with an API request to get a registration token for the runner service.
+    - Spin up an EC2 instance, supplying the registration token with the user data.
+    - The EC2 instance will use the runner service to make the instance available to the workflow
+      job
+* If the action for the workflow job is `completed`:
+    - Sign a token for a Github API request using the Github App private key.
+    - Use the token to request the idle runners from the Github API
+    - Kill the EC2 instance associated with the idle runner
 
 ## Building the Infrastructure
 
@@ -22,6 +72,10 @@ via port 443.
 There are therefore two different security groups: one for building the AMI and the other for
 running the agent during the CI process. The former group will open inbound SSH and outbound port
 80/443, and the latter will only open outbound port 443.
+
+Before the Terraform run is performed, the `secrets.tf` file must be unencrypted. It is encrypted
+using `git-crypt`, which uses GPG. You need to request access from someone who has already had their
+GPG key added to the repo. Once your key is added, the file can be decrypted using `git-crypt unlock`.
 
 To create the infrastructure you should use the `gha_runner_infra` user.
 
@@ -55,19 +109,15 @@ PACKER_VAR_ssh_private_key_file_path=<path to file>
 
 Now run `make build-image`.
 
-## Deploying the Create Instance Lambda Function
+## Create Instance Lambda Function
 
 This process requires the creation of the Terraform infrastructure above.
 
-The Github app for the self-hosted runner is installed at the organisation level. The app allows you
-to provide a webhook where it will post a `workflow_job` event. This webhook hits an AWS Lambda
-function, which then launches an EC2 instance.
-
 The Lambda function is deployed using the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html), so install this.
-You should use the `gha_runner_deploy` user for this process.
+You should use the `manage_runners_deploy` user for this process.
 
 The Lambda is packaged in a Docker container, which gets pushed to the private registry on the AWS
-account. You need to login to the registry with the `gha_runner_deploy` user:
+account. You need to login to the registry with the `manage_runners_deploy` user:
 ```
 aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin <AWS_ACCOUNT_NO.dkr.ecr.eu-west-2.amazonaws.com
 ```
@@ -77,9 +127,9 @@ Replace the account number here with our AWS account number.
 Define the following environment variables:
 ```
 AWS_ACCOUNT_NUMBER=<account number>
-AWS_ACCESS_KEY_ID=<access key ID of gha_runner_image_builder>
+AWS_ACCESS_KEY_ID=<access key ID of manage_runners_deploy>
 AWS_DEFAULT_REGION=eu-west-2
-AWS_SECRET_ACCESS_KEY=<secret access key of gha_runner_image_builder>
+AWS_SECRET_ACCESS_KEY=<secret access key of manage_runners_deploy>
 ```
 
 Now run `deploy-create-instance-function`.

--- a/gha-runner.pkr.hcl
+++ b/gha-runner.pkr.hcl
@@ -72,7 +72,7 @@ source "amazon-ebs" "ubuntu" {
     device_name = "/dev/sdb"
     delete_on_termination = true
     volume_type = "gp3"
-    volume_size = 50
+    volume_size = 100
   }
 }
 

--- a/lambda/manage_runners/app.py
+++ b/lambda/manage_runners/app.py
@@ -47,8 +47,8 @@ su ubuntu <<'EOF'
 cd /home/ubuntu
 REGISTRATION_TOKEN="__REGISTRATION_TOKEN__"
 RUNNER_BASE_URL="https://github.com/actions/runner/releases/download"
-RUNNER_VERSION="v2.299.1"
-RUNNER_ARCHIVE_NAME="actions-runner-linux-x64-2.299.1.tar.gz"
+RUNNER_VERSION="v2.317.0"
+RUNNER_ARCHIVE_NAME="actions-runner-linux-x64-2.317.0.tar.gz"
 SAFE_NETWORK_REPO_URL="https://github.com/maidsafe/safe_network"
 
 cd /mnt/data/runner

--- a/lambda/template.yaml
+++ b/lambda/template.yaml
@@ -8,7 +8,7 @@ Globals:
     Timeout: 30
 Parameters:
   AmiId:
-    Default: ami-00632730219704074
+    Default: ami-0e5143ec7835743eb
     Description: The AMI for the EC2 instance to be launched
     Type: String
   Ec2IamInstanceProfile:

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,15 @@ resource "aws_security_group_rule" "gha_runner_egress_ssh" {
   security_group_id = aws_security_group.gha_runner.id
 }
 
+resource "aws_security_group_rule" "gha_runner_egress_http" {
+  type = "egress"
+  from_port = 80
+  to_port = 80
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.gha_runner.id
+}
+
 resource "aws_security_group_rule" "gha_runner_egress_https" {
   type = "egress"
   from_port = 443
@@ -95,7 +104,7 @@ resource "aws_security_group_rule" "gha_runner_image_builder_egress_https" {
 
 resource "aws_key_pair" "gha_runner_image_builder" {
   key_name = var.gha_runner_image_builder_key_name
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDAY9iAxRT1zBwy8Zf9p9pR0rHwEaOL/6aGsQ2X70emFDVED+ms6w0Rgm8uEaZ1g2r/MBuiz3KlNEXcBrlcPkHIX+80/3ypvJtuH2h6t56cs8lVO8PJFeaBYEJstXEOf/QKDFIUPTstZH95lnyHS+11HQ5gxlHGMHW3tepXnZ3rN5BJzGGzhEWd/U50saBRgE0g4GHGebZprGPteRNGASwJXNRIbzwNdPUbIwxQBhwVrI15Sz/o4bvjGd1AfUgy4OMbrOQPVZHFD75K1w4rQeEQ6fGGHiV1rjuKBVgyeRmqPS3rVHss3Wq11GtHTGGxsMC4OLH4zosmoMrdO4gwvl/O8T7u6LadO/7ACMqGd7ctfLAlW1jqRPz1BSxklQgwAPduvBNvV81RV6B59ChltJa83X42BG6KkJAMIyfnNchuR2BALGutILWh8ualOl501qTaF+sPVM0HqjK9ow0lRU3UX9n4RvqEmS+Onch7SiTn5tBpDmikxhboADDhyczJ0/0="
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3RDMNQXEwJETQTRAG/ndJDESw5XwUR1NUxiegzOvj6pb0es3qUEcZGEUfFyVlSxyPZcCiizetHJMhRZN5qM/6UjUL7iDtWRLR3bq3I7iLTgZOs57QCQ/BEG70yah+xQRMDT5lt3lYxp4gKhDQgIdOtJJWEOg/KNnSP9SBZRR3Ris9rP8OiG7HR+QXDpDHwNXBVDjFGxAN3iN3osGwKO+KVai7OTT7mpzJJ0wbKvQOU+AdcqDE50POQBuyXDAm6j7mDrcLSUlNg3zDFvihbR6wcIAoUBJXoDC9LOtXuDwSw1AvS3dgC9Ij4R3eGHIobmK6qv8+ZPxe1BdxPVdjLCwb"
 }
 
 resource "aws_secretsmanager_secret" "github_app_id" {


### PR DESCRIPTION
- b99edbc **docs: explain the self hosted build agent setup**

  After coming back to this repository two years later and trying to figure out how to get it running
  again, I decided to document anything I found lacking. It turns out there wasn't really much of a
  description of the different parts in the infrastructure and how they fit together.

- 698fdf8 **chore: misc changes for getting the setup running**

  * Port 80 was opened on the GHA runner security group to avoid errors when installing apt packages.
  * The SSH key used for generating the build agent image had been lost. It was replaced.
  * The Ubuntu AMI was rebuilt because it was now two years old.
  * Doubled the size of the attached disk from 50 to 100GB. This is just to be really safe when going
    through the publishing process for the stable release.
  * The Makefile had invalid names for a couple of Terraform outputs. Don't know how these targets
    ever worked, but they do now.